### PR TITLE
Fix issues when multiple instances per domain and when hung up on

### DIFF
--- a/embed-script/src/C2CWidget.ts
+++ b/embed-script/src/C2CWidget.ts
@@ -202,6 +202,12 @@ export default class C2CWidget extends HTMLElement {
         this.closeModal();
       });
 
+      // widget is destroyed when the call is ended
+      // github.com/signalwire/call-widget/issues/7
+      callInstance?.on("destroy", () => {
+        this.closeModal();
+      });
+
       controlsPanel.appendChild(control);
 
       try {

--- a/embed-script/src/Call.ts
+++ b/embed-script/src/Call.ts
@@ -97,6 +97,12 @@ export class Call {
     onChatChange: (chatHistory: ChatEntry[]) => void,
     onLocalVideo: (localVideo: HTMLVideoElement) => void
   ) {
+    // Remove all SAT keys from session storage before dial
+    // github.com/signalwire/call-widget/issues/8
+    ["ci-SAT", "pt-SAT", "as-SAT"].forEach((key) =>
+      sessionStorage.removeItem(key)
+    );
+
     const client = await this.setupClient();
     this.chat = new Chat();
 


### PR DESCRIPTION
https://github.com/signalwire/call-widget/issues/8

- Before every client setup/dial, widget clears *-SAT entries: `['ci-SAT', 'pt-SAT', 'as-SAT'].forEach(key => sessionStorage.removeItem(key))`

https://github.com/signalwire/call-widget/issues/7

- Modal closes if Sigmond hangs up the call (`destroy` event)