### PR TITLE
Allow users to set userVariables through the c2c-widget tag

### DIFF
--- a/embed-script/index.html
+++ b/embed-script/index.html
@@ -103,8 +103,8 @@
 
     <c2c-widget
       buttonId="callButton"
-      callDetails='{"destination":"/private/demo-1","supportsVideo":true,"supportsAudio":true}'
-      token="%VITE_PUBLIC_TOKEN%"
+      callDetails='{"destination":"/private/aprilkisses","supportsVideo":false,"supportsAudio":true}'
+      token="c2c_3eaa2a89d96107a630fff087bc255e27"
     ></c2c-widget>
 
     <script type="module" src="/src/index.ts"></script>

--- a/embed-script/package-lock.json
+++ b/embed-script/package-lock.json
@@ -1,20 +1,20 @@
 {
   "name": "@niravcodes/call-widget",
-  "version": "1.0.0",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@niravcodes/call-widget",
-      "version": "1.0.0",
+      "version": "2.2.0",
       "dependencies": {
-        "@signalwire/js": "*",
-        "tslib": "^2.8.1"
+        "@signalwire/js": "dev"
       },
       "devDependencies": {
         "@types/react": "^18.0.0",
         "sass": "^1.86.0",
         "terser": "^5.39.0",
+        "tslib": "^2.8.1",
         "typescript": "~5.7.2",
         "vite": "^6.2.6"
       },
@@ -1976,7 +1976,8 @@
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true
     },
     "node_modules/typescript": {
       "version": "5.7.3",

--- a/embed-script/package.json
+++ b/embed-script/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@niravcodes/call-widget",
   "private": false,
-  "version": "1.0.0",
+  "version": "2.2.0",
   "type": "module",
   "main": "./dist/c2c-widget.umd.js",
   "module": "./dist/c2c-widget.es.js",
@@ -30,11 +30,11 @@
     "terser": "^5.39.0",
     "typescript": "~5.7.2",
     "vite": "^6.2.6",
-    "@types/react": "^18.0.0"
+    "@types/react": "^18.0.0",
+    "tslib": "^2.8.1"
   },
   "dependencies": {
-    "@signalwire/js": "dev",
-    "tslib": "^2.8.1"
+    "@signalwire/js": "dev"
   },
   "peerDependencies": {
     "react": ">=16.8.0"

--- a/embed-script/src/Call.ts
+++ b/embed-script/src/Call.ts
@@ -115,7 +115,10 @@ export class Call {
   }
 
   addUserVariables(variables: UserVariables) {
-    this.userVariables = variables;
+    this.userVariables = {
+      ...this.userVariables,
+      ...variables,
+    };
   }
 
   async dial(
@@ -136,6 +139,11 @@ export class Call {
       throw new Error("Call details are not set");
     }
 
+    const finalUserVariables = {
+      callOriginHref: window.location.href,
+      ...this.userVariables,
+    };
+
     // Add user variables to the room session
     const roomSession = await client.dial({
       to: this.callDetails.destination,
@@ -143,14 +151,16 @@ export class Call {
       audio: this.callDetails.supportsAudio,
       video: this.callDetails.supportsVideo,
       negotiateVideo: this.callDetails.supportsVideo,
-      userVariables: {
-        callOriginHref: window.location.href,
-        userName: this.userVariables?.userName ?? "",
-        userEmail: this.userVariables?.userEmail ?? "",
-        userPhone: this.userVariables?.userPhone ?? "",
-      },
+      userVariables: finalUserVariables,
     });
     this.currentCall = roomSession;
+
+    console.info(
+      "Call started",
+      this.currentCall,
+      "with user variables",
+      finalUserVariables
+    );
 
     roomSession.on("call.joined", () => {
       // @ts-ignore

--- a/embed-script/src/types.d.ts
+++ b/embed-script/src/types.d.ts
@@ -9,6 +9,7 @@ declare global {
           token?: string;
           buttonId?: string;
           callDetails?: string;
+          userVariables?: string;
         },
         HTMLElement
       >;


### PR DESCRIPTION
```html
   <c2c-widget
      buttonId="<id>"
      token="<token>"
      callDetails='<call details json>'
      userVariables='<user variables json>'
      collectUserDetails="false" <!-- whether to display the form -->
    ></c2c-widget>
 ```

This PR adds the `userVariables` attribute, that gets passed to FS and SWML explicitly.

Note:

1. `callOriginHref` userVariable always gets sent
2. `userName`, `userEmail`, and `userPhone` gets passed if the form is enabled, and user has filled them in
3. if you're manually setting `userName` or related properties rather than the form, it WILL get overwritten, don't use those vars.