### PR TITLE
Export the full bundle as well as the minimal bundle

### DIFF
--- a/doc-for-c2c-widget/package-lock.json
+++ b/doc-for-c2c-widget/package-lock.json
@@ -12,7 +12,7 @@
         "@docusaurus/preset-classic": "3.4.0",
         "@docusaurus/theme-mermaid": "^3.4.0",
         "@mdx-js/react": "^3.0.0",
-        "@niravcodes/call-widget": "^1.0.0",
+        "@niravcodes/call-widget": "^2.3.0",
         "clsx": "^2.0.0",
         "dotenv": "^16.5.0",
         "prism-react-renderer": "^2.3.0",
@@ -2844,12 +2844,11 @@
       }
     },
     "node_modules/@niravcodes/call-widget": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@niravcodes/call-widget/-/call-widget-1.0.0.tgz",
-      "integrity": "sha512-I3MoXBXPwy8xN2IVO+GS0JDKIw6oUCIV3tl4YMeOZ2nRfrKR+4xf/JzNSJm1cyPTD9Rwmhn1jszOxndsSF6zpg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@niravcodes/call-widget/-/call-widget-2.3.0.tgz",
+      "integrity": "sha512-IWtC1j5tbGEP3Wf3aV7iwiIAZyBYm4qMmY8F6kfVykwBtfE9kuBcktlNKDd/FKJfTdqL4bM4eAPddnI/xXq6Iw==",
       "dependencies": {
-        "@signalwire/js": "dev",
-        "tslib": "^2.8.1"
+        "@signalwire/js": "dev"
       },
       "peerDependencies": {
         "react": ">=16.8.0"

--- a/doc-for-c2c-widget/package.json
+++ b/doc-for-c2c-widget/package.json
@@ -19,7 +19,7 @@
     "@docusaurus/preset-classic": "3.4.0",
     "@docusaurus/theme-mermaid": "^3.4.0",
     "@mdx-js/react": "^3.0.0",
-    "@niravcodes/call-widget": "^1.0.0",
+    "@niravcodes/call-widget": "^2.3.0",
     "clsx": "^2.0.0",
     "dotenv": "^16.5.0",
     "prism-react-renderer": "^2.3.0",

--- a/embed-script/package-lock.json
+++ b/embed-script/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@niravcodes/call-widget",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@niravcodes/call-widget",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "dependencies": {
         "@signalwire/js": "dev"
       },

--- a/embed-script/package.json
+++ b/embed-script/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@niravcodes/call-widget",
   "private": false,
-  "version": "2.2.0",
+  "version": "2.3.0",
   "type": "module",
   "main": "./dist/c2c-widget.umd.js",
   "module": "./dist/c2c-widget.es.js",
@@ -18,8 +18,9 @@
   },
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
-    "pushToCDN": "npm run build && cd ../embed-script && scp dist/widget.js swrooms:/root/cdn/c2c-widget.js",
+    "build:external": "vite build --config vite.config.external.ts",
+    "build:full": "vite build --config vite.config.fullbundle.ts",
+    "build": "tsc && npm run build:external && npm run build:full",
     "preview": "vite preview",
     "serve": "vite preview --host",
     "push": "npm run build && npm run pushToCDN && npm run pushToCDN:dev",

--- a/embed-script/vite.config.external.ts
+++ b/embed-script/vite.config.external.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from "vite";
+import type { ModuleFormat } from "rollup";
+
+export default defineConfig({
+  build: {
+    lib: {
+      entry: "src/index.ts",
+      name: "C2CWidget",
+      formats: ["es", "umd"],
+      fileName: (format: ModuleFormat) => `c2c-widget.${format}.js`,
+    },
+    rollupOptions: {
+      external: ["@signalwire/js"],
+      output: {
+        globals: {
+          "@signalwire/js": "SignalWire",
+        },
+      },
+    },
+    minify: true,
+    sourcemap: true,
+    outDir: "dist",
+  },
+});

--- a/embed-script/vite.config.fullbundle.ts
+++ b/embed-script/vite.config.fullbundle.ts
@@ -5,18 +5,15 @@ export default defineConfig({
     lib: {
       entry: "src/index.ts",
       name: "C2CWidget",
-      formats: ["es", "umd"],
-      fileName: (format) => `c2c-widget.${format}.js`,
+      formats: ["umd"],
+      fileName: () => "c2c-widget-full.umd.js",
     },
     rollupOptions: {
-      external: ["@signalwire/js"],
-      output: {
-        globals: {
-          "@signalwire/js": "SignalWire",
-        },
-      },
+      external: [],
     },
     minify: true,
     sourcemap: true,
+    outDir: "dist",
+    emptyOutDir: false,
   },
 });


### PR DESCRIPTION
Now you use this single script

```html
<script src="https://cdn.jsdelivr.net/npm/@niravcodes/call-widget@2.3.0/dist/c2c-widget-full.umd.min.js
" defer></script>
```

instead of this:

```html
<script src="https://cdn.jsdelivr.net/npm/@niravcodes/call-widget@2.3.0/dist/c2c-widget.umd.min.js" defer></script>
<script type="text/javascript" src="https://cdn.signalwire.com/@signalwire/js@dev"></script>
```

In the `c2c-widget-full.umd.min.js` file, the correct dep of @signalwire/js is bundled in. 

In the `c2c-widget.umd.min.js` file, you need to import signalwire separately.

Both ways are equally valid so it's up to your requirements what you use.