### PR TITLE
Add events `call.joined` and `call.left`

### DIFF
--- a/embed-script/index.html
+++ b/embed-script/index.html
@@ -130,7 +130,7 @@
         const name = document.getElementById("userName").value;
         const petName = document.getElementById("petName").value;
 
-        const widget = document.getElementById("c2cWidget");
+        const widget = document.querySelector("c2c-widget");
 
         const userVariables = {
           email,
@@ -153,6 +153,12 @@
       const widget2 = document.querySelector("c2c-widget");
       widget2.addEventListener("beforecall", () => {
         console.log("beforecall");
+      });
+      widget2.addEventListener("call.joined", ({ detail }) => {
+        console.log("call.joined", detail);
+      });
+      widget2.addEventListener("call.left", ({ detail }) => {
+        console.log("call.left", detail);
       });
     </script>
 

--- a/embed-script/src/C2CWidget.ts
+++ b/embed-script/src/C2CWidget.ts
@@ -128,7 +128,7 @@ export default class C2CWidget extends HTMLElement {
     }
 
     if (this.callDetails && this.token) {
-      this.call = new Call(this.callDetails, this.token);
+      this.call = new Call(this.callDetails, this.token, this);
       if (this.userVariables) {
         this.call.addUserVariables(this.userVariables);
       }
@@ -287,6 +287,14 @@ export default class C2CWidget extends HTMLElement {
       });
 
       callInstance?.on("destroy", () => {
+        const callEndedEvent = new CustomEvent("call.left", {
+          detail: {
+            call: this.call?.currentCall,
+          },
+          bubbles: true,
+        });
+        this.dispatchEvent(callEndedEvent);
+
         this.closeModal(true);
       });
 

--- a/embed-script/src/Call.ts
+++ b/embed-script/src/Call.ts
@@ -17,14 +17,16 @@ export interface UserVariables {
 export class Call {
   private client: SignalWireClient | null = null;
   private callDetails: CallDetails | null = null;
+  private widget: HTMLElement;
   chat: Chat | null = null;
   currentCall: FabricRoomSession | null = null;
   token: string | null = null;
   private userVariables: UserVariables | null = null;
 
-  constructor(callDetails: CallDetails, token: string) {
+  constructor(callDetails: CallDetails, token: string, widget: HTMLElement) {
     this.callDetails = callDetails;
     this.token = token;
+    this.widget = widget;
   }
 
   private async getWidgetToken(embedsToken: string) {
@@ -163,6 +165,14 @@ export class Call {
     );
 
     roomSession.on("call.joined", () => {
+      const callStartedEvent = new CustomEvent("call.joined", {
+        detail: {
+          call: this.currentCall,
+          client: this.client,
+        },
+        bubbles: true,
+      });
+      this.widget.dispatchEvent(callStartedEvent);
       // @ts-ignore
       window.call = roomSession;
       if (roomSession?.localStream) {


### PR DESCRIPTION
up at v2.6.0

The events now:

`beforecall` fires after user clicks on the widget opening button. Call hasn't started yet, so you can set `userVariables` attribute here, for example, from a form.

`call.joined`  fires as the call has connected and audio/video transmission has just begun. Gives you `{detail:{call,client}}`

`call.left`  fires after the destroy event, so after hanging up. It gives you `{detail:{call}}` 

Example:

```
    <button id="callButton">start</button>
    <c2c-widget
      buttonId="callButton"
      callDetails='{"destination":"/private/demo-1","supportsVideo":true,"supportsAudio":true}'
      token=""
    ></c2c-widget>

    <script>
      const widget2 = document.querySelector("c2c-widget");
      widget2.addEventListener("beforecall", () => {
        console.log("beforecall");
      });
      widget2.addEventListener("call.joined", ({ detail }) => {
        console.log("call.joined", detail);
      });
      widget2.addEventListener("call.left", () => {
        console.log("call.left", detail);
      });
    </script>
```


NOTE: highly unstable API, don't rely on this existing as is.